### PR TITLE
Fix seller account creation check

### DIFF
--- a/src/main/java/it/epicode/security/auth/AuthRunner.java
+++ b/src/main/java/it/epicode/security/auth/AuthRunner.java
@@ -34,7 +34,7 @@ public class AuthRunner implements ApplicationRunner {
 
         // Creazione dell'utente seller se non esiste
         Optional<AppUser> normalSeller = appUserService.findByUsername("seller");
-        if (normalUser.isEmpty()) {
+        if (normalSeller.isEmpty()) {
             appUserService.registerUser("seller", "sellerpwd", Set.of(Role.ROLE_SELLER));
         }
 


### PR DESCRIPTION
## Summary
- fix incorrect variable used when checking if default seller exists

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68402893c2d0832c96b14dc2b85d187b